### PR TITLE
MODDATAIMP-1225 - Add dependency on app-data-import

### DIFF
--- a/app-bulk-edit.template.json
+++ b/app-bulk-edit.template.json
@@ -19,6 +19,10 @@
       {
         "name": "app-inventory",
         "version": "^1.0.0-SNAPSHOT"
+      },
+      {
+        "name": "app-data-import",
+        "version": "^1.0.0-SNAPSHOT"
       }
     ],
     "modules": [

--- a/application.template.json
+++ b/application.template.json
@@ -23,6 +23,11 @@
         "name": "app-inventory",
         "version": "^1.0.0-SNAPSHOT",
         "preRelease": "only"
+      },
+      {
+        "name": "app-data-import",
+        "version": "^1.0.0-SNAPSHOT",
+        "preRelease": "only"
       }
     ],
     "modules": [


### PR DESCRIPTION
## Purpose
The mod-source-record-manager and mod-di-converter-storage modules, on which mod-bulk-edit depends, are being extracted from the app-platform-complete to the app-data-import application. Therefore, a dependency on the app-data-import application should be added to the app-bulk-edit application descriptor




## Learning
[MODDATAIMP-1225](https://issues.folio.org/browse/MODDATAIMP-1225)